### PR TITLE
Charles/input path swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ public class App {
 
         // Perform the request against OPA.
         try {
-            allowed = opa.check(input, "policy/allow");
-            violations = opa.evaluate(input, "policy/violations");
+            allowed = opa.check("policy/allow", input);
+            violations = opa.evaluate("policy/violations", input);
         } catch (OPAException e ) {
             // Note that OPAException usually wraps other exception types, in
             // case you need to do more complex error handling.

--- a/src/main/java/com/styra/opa/OPAClient.java
+++ b/src/main/java/com/styra/opa/OPAClient.java
@@ -105,24 +105,24 @@ public class OPAClient {
      * @return
      * @throws OPAException
      */
-    public boolean check(java.util.Map<String, Object> input, String path) throws OPAException {
-        return evaluate(input, path);
+    public boolean check(String path, java.util.Map<String, Object> input) throws OPAException {
+        return evaluate(path, input);
     }
 
-    public boolean check(String input, String path) throws OPAException {
-        return evaluate(input, path);
+    public boolean check(String path, String input) throws OPAException {
+        return evaluate(path, input);
     }
 
-    public boolean check(boolean input, String path) throws OPAException {
-        return evaluate(input, path);
+    public boolean check(String path, boolean input) throws OPAException {
+        return evaluate(path, input);
     }
 
-    public boolean check(double input, String path) throws OPAException {
-        return evaluate(input, path);
+    public boolean check(String path, double input) throws OPAException {
+        return evaluate(path, input);
     }
 
-    public boolean check(java.util.List<Object> input, String path) throws OPAException {
-        return evaluate(input, path);
+    public boolean check(String path, java.util.List<Object> input) throws OPAException {
+        return evaluate(path, input);
     }
 
     /**
@@ -131,6 +131,10 @@ public class OPAClient {
      *
      * The other overloaded variations of this method behave similar, but allow
      * any valid JSON value to be used as the input document.
+     *
+     * If the input value is omitted, then an empty object is implicitly used
+     * as the input.
+     *
      *
      * @param input Input document for OPA query.
      * @param path Path to rule head to query, for example to access a rule
@@ -141,24 +145,28 @@ public class OPAClient {
      * com.fasterxml.jackson.databind.ObjectMapper.
      * @throws OPAException
      */
-    public <T> T evaluate(java.util.Map<String, Object> input, String path) throws OPAException {
+    public <T> T evaluate(String path, java.util.Map<String, Object> input) throws OPAException {
         return evaluateMachinery(Input.of(input), path);
     }
 
-    public <T> T evaluate(String input, String path) throws OPAException {
+    public <T> T evaluate(String path, String input) throws OPAException {
         return evaluateMachinery(Input.of(input), path);
     }
 
-    public <T> T evaluate(boolean input, String path) throws OPAException {
+    public <T> T evaluate(String path, boolean input) throws OPAException {
         return evaluateMachinery(Input.of(input), path);
     }
 
-    public <T> T evaluate(double input, String path) throws OPAException {
+    public <T> T evaluate(String path, double input) throws OPAException {
         return evaluateMachinery(Input.of(input), path);
     }
 
-    public <T> T evaluate(java.util.List<Object> input, String path) throws OPAException {
+    public <T> T evaluate(String path, java.util.List<Object> input) throws OPAException {
         return evaluateMachinery(Input.of(input), path);
+    }
+
+    public <T> T evaluate(String path) throws OPAException {
+        return evaluateMachinery(Input.of(Map.ofEntries()), path);
     }
 
     /**

--- a/src/test/java/com/styra/opa/OPATest.java
+++ b/src/test/java/com/styra/opa/OPATest.java
@@ -157,4 +157,23 @@ class OPATest {
         assertEquals(Map.ofEntries(), result);
     }
 
+    @Test
+    public void testOPAEcho() {
+        OPAClient opa = new OPAClient(address, headers);
+        Map result = Map.ofEntries(entry("unit", "test"));
+        Map expect = Map.ofEntries(entry("hello", "world"), entry("foo", Map.ofEntries(entry("bar", testNumberA))));
+
+        try {
+            result = opa.evaluate("policy/echo", Map.ofEntries(
+                entry("hello", "world"),
+                entry("foo", Map.ofEntries(entry("bar", testNumberA)))
+            ));
+        } catch (OPAException e) {
+            System.out.println("exception: " + e);
+            assertNull(e);
+        }
+
+        assertEquals(expect, result);
+    }
+
 }

--- a/src/test/java/com/styra/opa/OPATest.java
+++ b/src/test/java/com/styra/opa/OPATest.java
@@ -82,10 +82,10 @@ class OPATest {
         String result = "";
 
         try {
-            result = opa.evaluate(Map.ofEntries(
+            result = opa.evaluate("policy/hello", Map.ofEntries(
                 entry("user", "alice"),
                 entry("x", testNumberA)
-            ), "policy/hello");
+            ));
         } catch (OPAException e) {
             System.out.println("exception: " + e);
             assertNull(e);
@@ -100,10 +100,10 @@ class OPATest {
         boolean result = false;
 
         try {
-            result = opa.check(Map.ofEntries(
+            result = opa.check("policy/user_is_alice", Map.ofEntries(
                 entry("user", "alice"),
                 entry("x", testNumberA)
-            ), "policy/user_is_alice");
+            ));
         } catch (OPAException e) {
             System.out.println("exception: " + e);
             assertNull(e);
@@ -112,10 +112,10 @@ class OPATest {
         assertEquals(true, result);
 
         try {
-            result = opa.check(Map.ofEntries(
+            result = opa.check("policy/user_is_alice", Map.ofEntries(
                 entry("user", "bob"),
                 entry("x", testNumberA)
-            ), "policy/user_is_alice");
+            ));
         } catch (OPAException e) {
             System.out.println("exception: " + e);
             assertNull(e);
@@ -130,16 +130,31 @@ class OPATest {
         double result = 0;
 
         try {
-            result = opa.evaluate(Map.ofEntries(
+            result = opa.evaluate("policy/input_x_times_2", Map.ofEntries(
                 entry("user", "alice"),
                 entry("x", testNumberA)
-            ), "policy/input_x_times_2");
+            ));
         } catch (OPAException e) {
             System.out.println("exception: " + e);
             assertNull(e);
         }
 
         assertEquals(testNumberB, result);
+    }
+
+    @Test
+    public void testOPAWithoutInput() {
+        OPAClient opa = new OPAClient(address, headers);
+        Map result = Map.ofEntries(entry("unit", "test"));
+
+        try {
+            result = opa.evaluate("policy/echo");
+        } catch (OPAException e) {
+            System.out.println("exception: " + e);
+            assertNull(e);
+        }
+
+        assertEquals(Map.ofEntries(), result);
     }
 
 }


### PR DESCRIPTION
This PR makes the `input` field on the `evaluate` and `check` methods optional, and also makes the `path` argument come first. 