### PR TITLE
fix using object inputs and outputs

### DIFF
--- a/src/main/java/com/styra/opa/OPAClient.java
+++ b/src/main/java/com/styra/opa/OPAClient.java
@@ -126,6 +126,12 @@ public class OPAClient {
         return evaluate(path, input);
     }
 
+    public boolean check(String path, java.lang.Object input) throws OPAException {
+        ObjectMapper om = new ObjectMapper();
+        Map<String, Object> iMap = om.convertValue(input, new TypeReference<Map<String, Object>>() {});
+        return evaluate(path, iMap);
+    }
+
     /**
      * Perform a query with an input document against a Rego rule head by its
      * path.

--- a/src/main/java/com/styra/opa/OPAClient.java
+++ b/src/main/java/com/styra/opa/OPAClient.java
@@ -1,6 +1,7 @@
 package com.styra.opa;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.styra.opa.openapi.OpaApiClient;
 import com.styra.opa.openapi.models.operations.ExecutePolicyWithInputRequest;
@@ -135,16 +136,140 @@ public class OPAClient {
      * If the input value is omitted, then an empty object is implicitly used
      * as the input.
      *
+     * Due to limitations in Java's generics, the type parameter T alone is not
+     * always sufficient to determine the correct type to coerce the output to
+     * (specifically with constructing the TypeReference to use with
+     * fasterxml's ObjectMapper). In particular, the compiler needs a little
+     * extra help when assigning the return of this method to an object. In
+     * such situations, you will need to also provide a toValueType. Some ways
+     * this might be accomplished are shown below:
+     *
+     * <pre>
+     * // likely to fail at compile time with:
+     * //     java.lang.ClassCastException ... cannot be cast to class MyObject
+     * MyObject obj = evaluate("/foo", "bar");
+     *
+     * // using a TypeReference (recommended method)
+     * MyObject obj = evaluate("/foo", "bar", TypeReference&#60;MyObject&#62;() {});
+     *
+     * // using ObjectMapper
+     * MyObject obj = evaluate("/foo", "bar", new ObjectMapper().constructType(instanceOfMyObject.getClass()));
+     *
+     * // using .class (can cause checking issue with classes that have type parameters)
+     * MyObject obj = evaluate("/foo", "bar", MyObject.class);
+     * </pre>
      *
      * @param input Input document for OPA query.
      * @param path Path to rule head to query, for example to access a rule
      * head "allow" in a Rego file that starts with "package main", you would
      * provide the value "main/allow".
+     * @param toValueType May optionally be used to provide an alternative
+     * type for output conversion. This is especially useful when reading
+     * the result of an OPA request into an object.
      * @return The return value is automatically coerced to have a type
      * matching the type parameter T using
      * com.fasterxml.jackson.databind.ObjectMapper.
      * @throws OPAException
      */
+    public <T> T evaluate(String path, java.util.Map<String, Object> input, Class<T> toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(input), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, String input, Class<T> toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(input), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, boolean input, Class<T> toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(input), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, double input, Class<T> toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(input), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, java.util.List<Object> input, Class<T> toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(input), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, Class<T> toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(Map.ofEntries()), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, java.lang.Object input, Class<T> toValueType) throws OPAException {
+        ObjectMapper om = new ObjectMapper();
+        Map<String, Object> iMap = om.convertValue(input, new TypeReference<Map<String, Object>>() {});
+        return evaluateMachinery(Input.of(iMap), path, toValueType);
+    }
+
+    // evaluate, but with JavaType toValueTypes
+
+    public <T> T evaluate(String path, java.util.Map<String, Object> input, JavaType toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(input), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, String input, JavaType toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(input), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, boolean input, JavaType toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(input), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, double input, JavaType toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(input), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, java.util.List<Object> input, JavaType toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(input), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, JavaType toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(Map.ofEntries()), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, java.lang.Object input, JavaType toValueType) throws OPAException {
+        ObjectMapper om = new ObjectMapper();
+        Map<String, Object> iMap = om.convertValue(input, new TypeReference<Map<String, Object>>() {});
+        return evaluateMachinery(Input.of(iMap), path, toValueType);
+    }
+
+    // evaluate, but with TypeReference toValueTypes
+
+    public <T> T evaluate(
+            String path,
+            java.util.Map<String, Object> input,
+            TypeReference<T> toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(input), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, String input, TypeReference<T> toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(input), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, boolean input, TypeReference<T> toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(input), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, double input, TypeReference<T> toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(input), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, java.util.List<Object> input, TypeReference<T> toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(input), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, TypeReference<T> toValueType) throws OPAException {
+        return evaluateMachinery(Input.of(Map.ofEntries()), path, toValueType);
+    }
+
+    public <T> T evaluate(String path, java.lang.Object input, TypeReference<T> toValueType) throws OPAException {
+        ObjectMapper om = new ObjectMapper();
+        Map<String, Object> iMap = om.convertValue(input, new TypeReference<Map<String, Object>>() {});
+        return evaluateMachinery(Input.of(iMap), path, toValueType);
+    }
+
+    // omit the toTypeValue and try to be smart
+
     public <T> T evaluate(String path, java.util.Map<String, Object> input) throws OPAException {
         return evaluateMachinery(Input.of(input), path);
     }
@@ -169,17 +294,14 @@ public class OPAClient {
         return evaluateMachinery(Input.of(Map.ofEntries()), path);
     }
 
-    /**
-     * General-purpose wrapper around the Speakeasy generated
-     * ExecutePolicyWithInputResponse API.
-     *
-     * @param input
-     * @param path
-     * @return
-     * @throws OPAException
-     */
-    private <T> T evaluateMachinery(Input input, String path) throws OPAException {
-        ExecutePolicyWithInputRequest req = ExecutePolicyWithInputRequest.builder()
+    public <T> T evaluate(String path, java.lang.Object input) throws OPAException {
+        ObjectMapper om = new ObjectMapper();
+        Map<String, Object> iMap = om.convertValue(input, new TypeReference<Map<String, Object>>() {});
+        return evaluateMachinery(Input.of(iMap), path);
+    }
+
+    private ExecutePolicyWithInputRequest makeRequestForEvaluate(Input input, String path) {
+        return ExecutePolicyWithInputRequest.builder()
             .path(path)
             .requestBody(ExecutePolicyWithInputRequestBody.builder()
                     .input(input).build())
@@ -190,7 +312,19 @@ public class OPAClient {
             .instrument(policyRequestInstrument)
             .strictBuiltinErrors(policyRequestStrictBuiltinErrors)
             .build();
+    }
 
+    /**
+     * General-purpose wrapper around the Speakeasy generated
+     * ExecutePolicyWithInputResponse API.
+     *
+     * @param input
+     * @param path
+     * @return
+     * @throws OPAException
+     */
+    private <T> T evaluateMachinery(Input input, String path) throws OPAException {
+        ExecutePolicyWithInputRequest req = makeRequestForEvaluate(input, path);
         ExecutePolicyWithInputResponse res;
 
         try {
@@ -218,4 +352,86 @@ public class OPAClient {
             return null;
         }
     }
+
+    private <T> T evaluateMachinery(Input input, String path, Class<T> toValueType) throws OPAException {
+        ExecutePolicyWithInputRequest req = makeRequestForEvaluate(input, path);
+        ExecutePolicyWithInputResponse res;
+
+        try {
+            res = sdk.executePolicyWithInput()
+                .request(req)
+                .call();
+
+        //CHECKSTYLE:OFF
+        } catch (Exception e) {
+            //CHECKSTYLE:ON
+            e.printStackTrace(System.out);
+            String msg = String.format("executing policy at '%s' with failed due to exception '%s'", path, e);
+            throw new OPAException(msg, e);
+        }
+
+        if (res.successfulPolicyEvaluation().isPresent()) {
+            Object out = res.successfulPolicyEvaluation().get().result().get().value();
+            ObjectMapper mapper = new ObjectMapper();
+            T typedResult = mapper.convertValue(out, toValueType);
+            return typedResult;
+        } else {
+            return null;
+        }
+    }
+
+    private <T> T evaluateMachinery(Input input, String path, JavaType toValueType) throws OPAException {
+        ExecutePolicyWithInputRequest req = makeRequestForEvaluate(input, path);
+        ExecutePolicyWithInputResponse res;
+
+        try {
+            res = sdk.executePolicyWithInput()
+                .request(req)
+                .call();
+
+        //CHECKSTYLE:OFF
+        } catch (Exception e) {
+            //CHECKSTYLE:ON
+            e.printStackTrace(System.out);
+            String msg = String.format("executing policy at '%s' with failed due to exception '%s'", path, e);
+            throw new OPAException(msg, e);
+        }
+
+        if (res.successfulPolicyEvaluation().isPresent()) {
+            Object out = res.successfulPolicyEvaluation().get().result().get().value();
+            ObjectMapper mapper = new ObjectMapper();
+            T typedResult = mapper.convertValue(out, toValueType);
+            return typedResult;
+        } else {
+            return null;
+        }
+    }
+
+    private <T> T evaluateMachinery(Input input, String path, TypeReference<T> toValueType) throws OPAException {
+        ExecutePolicyWithInputRequest req = makeRequestForEvaluate(input, path);
+        ExecutePolicyWithInputResponse res;
+
+        try {
+            res = sdk.executePolicyWithInput()
+                .request(req)
+                .call();
+
+        //CHECKSTYLE:OFF
+        } catch (Exception e) {
+            //CHECKSTYLE:ON
+            e.printStackTrace(System.out);
+            String msg = String.format("executing policy at '%s' with failed due to exception '%s'", path, e);
+            throw new OPAException(msg, e);
+        }
+
+        if (res.successfulPolicyEvaluation().isPresent()) {
+            Object out = res.successfulPolicyEvaluation().get().result().get().value();
+            ObjectMapper mapper = new ObjectMapper();
+            T typedResult = mapper.convertValue(out, toValueType);
+            return typedResult;
+        } else {
+            return null;
+        }
+    }
+
 }

--- a/src/test/java/com/styra/opa/AlternateSampleObject.java
+++ b/src/test/java/com/styra/opa/AlternateSampleObject.java
@@ -1,0 +1,30 @@
+package com.styra.opa;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+public class AlternateSampleObject {
+    @JsonProperty
+    private Map<String, java.lang.Object> nestedMap;
+
+    @JsonProperty
+    private String stringVal;
+
+    public Map<String, java.lang.Object> getNestedMap() {
+        return nestedMap;
+    }
+
+    public void setNestedMap(Map<String, java.lang.Object> newValue) {
+        nestedMap = newValue;
+    }
+
+    public String getStringVal() {
+        return stringVal;
+    }
+
+    public void setStringVal(String newValue) {
+        stringVal = newValue;
+    }
+
+}

--- a/src/test/java/com/styra/opa/OPATest.java
+++ b/src/test/java/com/styra/opa/OPATest.java
@@ -1,5 +1,6 @@
 package com.styra.opa;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.BindMode;
@@ -26,8 +27,9 @@ class OPATest {
 
     // Checkstyle does not like magic numbers, but these are just test values.
     // The B value should be double the A value.
-    private int testNumberA = 8;
-    private int testNumberB = 16;
+    private int testIntegerA = 8;
+    private int testIntegerB = 16;
+    private double testDoubleA = 3.14159;
 
     private String address;
     private Map<String, String> headers = Map.ofEntries(entry("Authorization", "Bearer supersecret"));
@@ -84,7 +86,7 @@ class OPATest {
         try {
             result = opa.evaluate("policy/hello", Map.ofEntries(
                 entry("user", "alice"),
-                entry("x", testNumberA)
+                entry("x", testIntegerA)
             ));
         } catch (OPAException e) {
             System.out.println("exception: " + e);
@@ -102,7 +104,7 @@ class OPATest {
         try {
             result = opa.check("policy/user_is_alice", Map.ofEntries(
                 entry("user", "alice"),
-                entry("x", testNumberA)
+                entry("x", testIntegerA)
             ));
         } catch (OPAException e) {
             System.out.println("exception: " + e);
@@ -114,7 +116,7 @@ class OPATest {
         try {
             result = opa.check("policy/user_is_alice", Map.ofEntries(
                 entry("user", "bob"),
-                entry("x", testNumberA)
+                entry("x", testIntegerA)
             ));
         } catch (OPAException e) {
             System.out.println("exception: " + e);
@@ -132,14 +134,14 @@ class OPATest {
         try {
             result = opa.evaluate("policy/input_x_times_2", Map.ofEntries(
                 entry("user", "alice"),
-                entry("x", testNumberA)
+                entry("x", testIntegerA)
             ));
         } catch (OPAException e) {
             System.out.println("exception: " + e);
             assertNull(e);
         }
 
-        assertEquals(testNumberB, result);
+        assertEquals(testIntegerB, result);
     }
 
     @Test
@@ -161,12 +163,12 @@ class OPATest {
     public void testOPAEcho() {
         OPAClient opa = new OPAClient(address, headers);
         Map result = Map.ofEntries(entry("unit", "test"));
-        Map expect = Map.ofEntries(entry("hello", "world"), entry("foo", Map.ofEntries(entry("bar", testNumberA))));
+        Map expect = Map.ofEntries(entry("hello", "world"), entry("foo", Map.ofEntries(entry("bar", testIntegerA))));
 
         try {
             result = opa.evaluate("policy/echo", Map.ofEntries(
                 entry("hello", "world"),
-                entry("foo", Map.ofEntries(entry("bar", testNumberA)))
+                entry("foo", Map.ofEntries(entry("bar", testIntegerA)))
             ));
         } catch (OPAException e) {
             System.out.println("exception: " + e);
@@ -176,4 +178,84 @@ class OPATest {
         assertEquals(expect, result);
     }
 
+    @Test
+    public void testObjectRoundtrip() {
+        OPAClient opa = new OPAClient(address, headers);
+
+        Map<String, String> sampleMap1 = Map.ofEntries(entry("hello", "world"));
+        Map<String, String> sampleMap2 = Map.ofEntries(entry("hello", "world"));
+
+        SampleObject<Double> input = new SampleObject<Double>();
+        input.setBoolProperty(true);
+        input.setIntProperty(testIntegerA);
+        input.setCustomProperty(testDoubleA);
+        input.setAnnotatedProperty(testIntegerB);
+        input.setMapProperty(sampleMap1);
+
+        SampleObject<Double> expect = new SampleObject<Double>();
+        expect.setBoolProperty(true);
+        expect.setIntProperty(testIntegerA);
+        expect.setCustomProperty(testDoubleA);
+        expect.setAnnotatedProperty(testIntegerB);
+        expect.setMapProperty(sampleMap2);
+
+        SampleObject<Double> actual = new SampleObject<Double>();
+
+        try {
+            //actual = opa.evaluate("policy/echo", input, new ObjectMapper().constructType(actual.getClass()));
+            actual = opa.evaluate("policy/echo", input, new TypeReference<SampleObject<Double>>() {});
+        } catch (OPAException e) {
+            System.out.println("exception: " + e);
+            assertNull(e);
+        }
+
+        assertEquals(input.getBoolProperty(), expect.getBoolProperty());
+        assertEquals(input.getIntProperty(), expect.getIntProperty());
+        assertEquals(input.getCustomProperty(), expect.getCustomProperty());
+        assertEquals(input.getAnnotatedProperty(), expect.getAnnotatedProperty());
+        assertEquals(input.getMapProperty(), expect.getMapProperty());
+    }
+
+    @Test
+    public void testObjectRoundtripWithTypeChange() {
+        OPAClient opa = new OPAClient(address, headers);
+
+        Map<String, String> sampleMap1 = Map.ofEntries(entry("hello", "world"));
+        Map<String, String> sampleMap2 = Map.ofEntries(entry("hello", "world"));
+
+        Map<String, java.lang.Object> expectNestedMap = Map.ofEntries(
+            entry("boolProperty", true),
+            entry("intProperty", testIntegerA),
+            entry("customProperty", testDoubleA),
+            entry("customAnnotatedProperty", testIntegerB),
+            entry("mapProperty", sampleMap1)
+        );
+
+        SampleObject<Double> input = new SampleObject<Double>();
+        input.setBoolProperty(true);
+        input.setIntProperty(testIntegerA);
+        input.setCustomProperty(testDoubleA);
+        input.setAnnotatedProperty(testIntegerB);
+        input.setMapProperty(sampleMap1);
+
+        AlternateSampleObject expect = new AlternateSampleObject();
+        expect.setNestedMap(expectNestedMap);
+        expect.setStringVal("hello, test suite!");
+
+        AlternateSampleObject actual = new AlternateSampleObject();
+
+        try {
+            actual = opa.evaluate(
+                    "policy/makeAlternateSampleClass",
+                    input,
+                    new TypeReference<AlternateSampleObject>() {}
+            );
+        } catch (OPAException e) {
+            System.out.println("exception: " + e);
+            assertNull(e);
+        }
+
+        assertEquals(actual.getNestedMap(), expect.getNestedMap());
+        assertEquals(actual.getStringVal(), expect.getStringVal());
+    }
 }

--- a/src/test/java/com/styra/opa/SampleObject.java
+++ b/src/test/java/com/styra/opa/SampleObject.java
@@ -1,0 +1,64 @@
+package com.styra.opa;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+public class SampleObject<T> {
+
+    @JsonProperty
+    private boolean boolProperty;
+
+    @JsonProperty
+    private int intProperty;
+
+    @JsonProperty
+    private T customProperty;
+
+    @JsonProperty("customAnnotatedProperty")
+    private int annotatedProperty;
+
+    @JsonProperty
+    private Map<String, String> mapProperty;
+
+    public boolean getBoolProperty() {
+        return boolProperty;
+    }
+
+    public void setBoolProperty(boolean newValue) {
+        boolProperty = newValue;
+    }
+
+    public int getIntProperty() {
+        return intProperty;
+    }
+
+    public void setIntProperty(int newValue) {
+        intProperty = newValue;
+    }
+
+    public T getCustomProperty() {
+        return customProperty;
+    }
+
+    public void setCustomProperty(T newValue) {
+        customProperty = newValue;
+    }
+
+    public int getAnnotatedProperty() {
+        return annotatedProperty;
+    }
+
+    public void setAnnotatedProperty(int newValue) {
+        annotatedProperty = newValue;
+    }
+
+    public Map<String, String> getMapProperty() {
+        return mapProperty;
+    }
+
+    public void setMapProperty(Map<String, String> newValue) {
+        mapProperty = newValue;
+    }
+
+}

--- a/testdata/simple/policy.rego
+++ b/testdata/simple/policy.rego
@@ -12,3 +12,7 @@ user_is_alice {
 
 hello := "Open Policy Agent"
 
+makeAlternateSampleClass := {
+    "nestedMap": input,
+    "stringVal": "hello, test suite!"
+}


### PR DESCRIPTION
This PR fixes two defects:

1. Using a Java object as an input to `evaluate` and `check` previously did not work, as an overloaded method with an appropriate type signature was not present. Now, we accept arbitrary objects and use ObjectMapper to convert them to maps before providing them to the low-level SDK.
2. Writing the result of an `evaluate()` call to an object value did not work correctly. As far as I can tell, this is because the implementation of generics in Java mean the type information needed to do so is lost. To address this, I have added new overloads to every invariant of `evaluate()` which allows providing the needed type information as a `Class<T>`, `JavaType`, or `TypeReference<T>`, which mirrors the API of ObjectMapper. This means users may now supply a custom type for the object to be converted into inline with the `evaluate()` call, avoiding the need for the API user to retrieve a map and perform that conversion themselves. 
