### PR TITLE
add GHA job to check release versions

### DIFF
--- a/.github/workflows/release_version_check.yaml
+++ b/.github/workflows/release_version_check.yaml
@@ -1,0 +1,34 @@
+name: "05 - Release Version Check"
+
+"on":
+  schedule:
+    - cron: 0 0 * * *
+
+jobs:
+  verscheck:
+    name: Check Release Versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - uses: actions/checkout@v4
+      - name: Setup OPA
+        uses: open-policy-agent/setup-opa@v2
+        with:
+          version: latest
+      - name: Run version-checker script
+        run: |
+          cd repo
+          ./scripts/check-released-versions.sh
+      - uses: ravsamhq/notify-slack-action@v2
+        if: always() && env.SLACK_WEBHOOK_URL != ''
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.github_access_token }}
+          notify_when: "failure"
+          notification_title: "Maven Central release for opa-java does not match GitHub release version"
+          message_format: "{emoji} *{workflow}* {status_message} in <{repo_url}|{repo}>, see release docs here: https://styrainc.github.io/opa-java/maintenance/releases/"
+          footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+

--- a/scripts/check-released-versions.sh
+++ b/scripts/check-released-versions.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# This script checks weather or not the latest GitHub release matches the
+# latest Maven Central release version. If the latest release was in the last
+# 24 hours, then it will always exit 0. If the releases don't match, it will
+# exit 1 and print a pertinent error message.
+
+set -e
+set -u
+set -x
+
+# https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases
+GITHUB_REPO="styrainc/opa-java"
+GITHUB_API_URL="https://api.github.com/repos/$GITHUB_REPO/releases"
+
+# https://central.sonatype.org/search/rest-api-guide/
+#
+# Note that there is further filtering done using opa eval later when
+# MAVEN_RELEASE is calculated.
+MAVEN_URL='https://search.maven.org/solrsearch/select?q=g:com.styra&rows=20&wt=json'
+
+# If the release is less than this many seconds old, ignore it.
+# 86400s == 1 day.
+IGNORE_WINDOW=86400
+
+# Notice the tr -d v to strip the leading v from the release tag.
+GH_RESPONSE="$(curl -LSs "$GITHUB_API_URL")"
+RELEASE_TAG="$(printf '%s' "$GH_RESPONSE" | opa eval -f pretty -I 'input[0].tag_name' | tr -d '"' | tr -d 'v')"
+RELEASE_TS="$(printf '%s' "$GH_RESPONSE"  | opa eval -f pretty -I 'input[0].published_at' | tr -d '"')"
+RELEASE_AGE="$(printf '{"ts": "%s"}' "$RELEASE_TS" | opa eval -f pretty -I 'ceil((time.now_ns() - time.parse_rfc3339_ns(input.ts))*0.000000001)')"
+
+printf "DEBUG: RELEASE_TAG='%s' RELEASE_TS='%s' RELEASE_AGE=%ds\n" "$RELEASE_TAG" "$RELEASE_TS" "$RELEASE_AGE" 1>&2
+
+if [ "$RELEASE_AGE" -lt "$IGNORE_WINDOW" ] ; then
+	printf "DEBUG: release is too new (%ds < %ds), skipping version check\n" "$RELEASE_AGE" "$IGNORE_WINDOW" 1>&2
+	exit 0
+fi
+
+MAVEN_RESPONSE="$(curl -LSs "$MAVEN_URL")"
+MAVEN_RELEASE="$(printf '%s' "$MAVEN_RESPONSE" | opa eval -f pretty -I '[d | d := input.response.docs[_]; d.a == "opa"][0].latestVersion' | tr -d '"')"
+
+if [ "$MAVEN_RELEASE" != "$RELEASE_TAG" ] ; then
+	echo "latest Maven release '$MAVEN_RELEASE' does not match latest GitHub release tag '$RELEASE_TAG'"
+	exit 1
+fi
+
+echo "latest Maven release '$MAVEN_RELEASE' matches latest GitHub release tag '$RELEASE_TAG'"
+exit 0


### PR DESCRIPTION
This PR adds a helper script which uses the Maven Central and GitHub APIs to get the latest GitHub release, get the latest Maven Central version, and ensure that the versions match each other. If they do not, it will send a Slack notification. This is intended to detect and escalate situations where a GH release has been completed, but the manual release steps to Maven Central have not. The Slack message includes a link to the appropriate release docs.

Because it takes time to complete the manual steps, and it also takes time after they are done before releases appear in Maven Central, the script will bail out early with a 0 exit code if the latest GH release is less than 24 hours old. 