### PR TITLE
implement e2e test for prefixed OPA APIs

### DIFF
--- a/src/test/java/com/styra/opa/OPATest.java
+++ b/src/test/java/com/styra/opa/OPATest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
@@ -25,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class OPATest {
 
     private int opaPort = 8181;
+    private int altPort = 8282;
 
     // Checkstyle does not like magic numbers, but these are just test values.
     // The B value should be double the A value.
@@ -33,6 +35,7 @@ class OPATest {
     private double testDoubleA = 3.14159;
 
     private String address;
+    private String altAddress;
     private Map<String, String> headers = Map.ofEntries(entry("Authorization", "Bearer supersecret"));
 
     @Container
@@ -44,8 +47,14 @@ class OPATest {
     // variables are supposed to be declared first. But then it would need to
     // have magic numbers since opaPort and friends are private.
     //CHECKSTYLE:OFF
-    public GenericContainer opac = new GenericContainer(DockerImageName.parse("openpolicyagent/opa:latest"))
-        .withExposedPorts(opaPort)
+    public GenericContainer<?> opac = new GenericContainer<>(
+            new ImageFromDockerfile()
+                // .withFileFromClasspath(path_in_build_context, path_in_resources_dir)
+                .withFileFromClasspath("Dockerfile", "opa.Dockerfile")
+                .withFileFromClasspath("nginx.conf", "nginx.conf")
+                .withFileFromClasspath("entrypoint.sh", "entrypoint.sh")
+        )
+        .withExposedPorts(opaPort, altPort)
         .withFileSystemBind("./testdata/simple", "/policy", BindMode.READ_ONLY)
         .withCommand("run -s --authentication=token --authorization=basic --bundle /policy");
     //CHECKSTYLE:ON
@@ -53,6 +62,7 @@ class OPATest {
     @BeforeEach
     public void setUp() {
         address = "http://" + opac.getHost() + ":" + opac.getMappedPort(opaPort);
+        altAddress = "http://" + opac.getHost() + ":" + opac.getMappedPort(altPort) + "/customprefix";
     }
 
     @AfterEach
@@ -69,6 +79,31 @@ class OPATest {
 
         HttpClient client = HttpClient.newHttpClient();
         HttpRequest req = HttpRequest.newBuilder().uri(URI.create(address + "/health")).build();
+        HttpResponse<String> resp = null;
+
+        try {
+            resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+        // This is a unit test, I will catch whatever exceptions I want.
+        //CHECKSTYLE:OFF
+        } catch (Exception e) {
+            //CHECKSTYLE:ON
+            System.out.println("exception: " + e);
+            assertNull(e);
+        }
+
+        String body = resp.body();
+
+        assertEquals("{}\n", body);
+    }
+
+    @Test
+    public void testOPAHealthAlternate() {
+        // This makes sure that we can also successfully reach the OPA health
+        // API on the "alternate", reverse-proxy based OPA that has a URL
+        // prefix.
+
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest req = HttpRequest.newBuilder().uri(URI.create(altAddress + "/health")).build();
         HttpResponse<String> resp = null;
 
         try {
@@ -227,6 +262,50 @@ class OPATest {
     @Test
     public void testObjectRoundtripWithTypeChange() {
         OPAClient opa = new OPAClient(address, headers);
+
+        Map<String, String> sampleMap1 = Map.ofEntries(entry("hello", "world"));
+        Map<String, String> sampleMap2 = Map.ofEntries(entry("hello", "world"));
+
+        Map<String, java.lang.Object> expectNestedMap = Map.ofEntries(
+            entry("boolProperty", true),
+            entry("intProperty", testIntegerA),
+            entry("customProperty", testDoubleA),
+            entry("customAnnotatedProperty", testIntegerB),
+            entry("mapProperty", sampleMap1)
+        );
+
+        SampleObject<Double> input = new SampleObject<Double>();
+        input.setBoolProperty(true);
+        input.setIntProperty(testIntegerA);
+        input.setCustomProperty(testDoubleA);
+        input.setAnnotatedProperty(testIntegerB);
+        input.setMapProperty(sampleMap1);
+
+        AlternateSampleObject expect = new AlternateSampleObject();
+        expect.setNestedMap(expectNestedMap);
+        expect.setStringVal("hello, test suite!");
+
+        AlternateSampleObject actual = new AlternateSampleObject();
+
+        try {
+            actual = opa.evaluate(
+                    "policy/makeAlternateSampleClass",
+                    input,
+                    new TypeReference<AlternateSampleObject>() {}
+            );
+        } catch (OPAException e) {
+            System.out.println("exception: " + e);
+            assertNull(e);
+        }
+
+        assertEquals(actual.getNestedMap(), expect.getNestedMap());
+        assertEquals(actual.getStringVal(), expect.getStringVal());
+    }
+
+    @Test
+    public void testObjectRoundtripWithTypeChangeAlternate() {
+        // Same as before, but using the alternate reverse-proxy OPA.
+        OPAClient opa = new OPAClient(altAddress, headers);
 
         Map<String, String> sampleMap1 = Map.ofEntries(entry("hello", "world"));
         Map<String, String> sampleMap2 = Map.ofEntries(entry("hello", "world"));

--- a/src/test/java/com/styra/opa/OPATest.java
+++ b/src/test/java/com/styra/opa/OPATest.java
@@ -9,7 +9,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
 import java.net.URI;
 import java.net.http.HttpClient;

--- a/src/test/resources/entrypoint.sh
+++ b/src/test/resources/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -x
+
+# We want to run nginx attached to the same foreground session as OPA, but
+# without blocking OPA. We can do this simply using Bash job control.
+nginx -g "daemon off;" &
+
+opa $@

--- a/src/test/resources/nginx.conf
+++ b/src/test/resources/nginx.conf
@@ -1,0 +1,19 @@
+# This nginx config creates an additional :8282 endpoint that prefixes the
+# OPA API with /customprefix/. This is used to test that the opa-java SDK
+# plays nicely with OPA hosted behind reverse proxy setups.
+
+events {}
+
+http {
+    server {
+        listen 8282;
+
+        location /customprefix/ {
+            proxy_pass http://localhost:8181/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/src/test/resources/opa.Dockerfile
+++ b/src/test/resources/opa.Dockerfile
@@ -1,23 +1,14 @@
 FROM alpine:latest
 
-RUN apk add go git nginx bash
+RUN apk add nginx bash
 
 ADD nginx.conf /etc/nginx/nginx.conf
 
 ADD entrypoint.sh /entrypoint.sh
 
-# Install the latest version of OPA from source, since we need nginx in the
-# container, OPA isn't packaged by Alpine, and the upstream OPA package
-# contains only OPA and no userland.
-RUN mkdir -p /src && \
-    cd /src && \
-    git clone https://github.com/open-policy-agent/opa.git && \
-    cd opa && \
-    git checkout "$(git tag | grep -v 'rc' | grep '^v' | sort -V | tail -n 1)" && \
-    go build -o /usr/bin/opa -ldflags="-s -w" ./ && \
-    cd /src && \
-    rm -rf ./opa && \
-    chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+COPY --from=openpolicyagent/opa:latest-static /opa /usr/bin/opa
 
 ENTRYPOINT ["/entrypoint.sh"]
 

--- a/src/test/resources/opa.Dockerfile
+++ b/src/test/resources/opa.Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:latest
+
+RUN apk add go git nginx bash
+
+ADD nginx.conf /etc/nginx/nginx.conf
+
+ADD entrypoint.sh /entrypoint.sh
+
+# Install the latest version of OPA from source, since we need nginx in the
+# container, OPA isn't packaged by Alpine, and the upstream OPA package
+# contains only OPA and no userland.
+RUN mkdir -p /src && \
+    cd /src && \
+    git clone https://github.com/open-policy-agent/opa.git && \
+    cd opa && \
+    git checkout "$(git tag | grep -v 'rc' | grep '^v' | sort -V | tail -n 1)" && \
+    go build -o /usr/bin/opa -ldflags="-s -w" ./ && \
+    cd /src && \
+    rm -rf ./opa && \
+    chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+


### PR DESCRIPTION
This PR modifies the existing E2E tests to use a new custom Dockerfile that also also serves a reverse-proxied version of the OPA API on an alternate `:8282` port, with the path prefix `/customprefix`. It also adds a few tests that validate that the OPA API at that address is correctly handled by checking the `/health` endpoint and also running a duplicate of one of the existing tests on the alternate address. 

This will act as a regression test to ensure we don't end up with an issue similar to [this one](https://github.com/StyraInc/opa-typescript/pull/65) from the TypeScript SDK.

There should be no user-facing functionality changes. 