### PR TITLE
implement support for latency measurement logging

### DIFF
--- a/src/main/java/com/styra/opa/OPAClient.java
+++ b/src/main/java/com/styra/opa/OPAClient.java
@@ -70,6 +70,18 @@ public class OPAClient {
     }
 
     /**
+     * This constructor can be used to instantiate an OPAClient which uses a
+     * custom HTTP client implementation for the underlying OpaApiClient.
+     *
+     * @param opaURL URL at which OPA should be connected to.
+     * @param httpclient custom HTTP client to use
+     */
+    public OPAClient(String opaURL, HTTPClient httpclient) {
+        this.sdkServerURL = opaURL;
+        this.sdk = OpaApiClient.builder().serverURL(opaURL).client(httpclient).build();
+    }
+
+    /**
      * This constructor allows instantiating the OPA wrapper with additional
      * HTTP headers to be injected into every request. This is intended to be
      * used with OPA bearer token authentication, which you can learn more

--- a/src/main/java/com/styra/opa/utils/OPALatencyMeasuringHTTPClient.java
+++ b/src/main/java/com/styra/opa/utils/OPALatencyMeasuringHTTPClient.java
@@ -1,0 +1,92 @@
+package com.styra.opa.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.text.MessageFormat;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.FINE;
+
+/**
+ * This HTTPClient implementation wraps OPAHTTPClient. In addition to
+ * (optionally) injecting extra headers into the requests, it can also send log
+ * messages to a java.util.logging.Logger instances with latency measurements.
+ */
+public class OPALatencyMeasuringHTTPClient extends OPAHTTPClient {
+
+    private Logger logger;
+
+    private String latencyMeasurementFormatString = "path=''{1}'' latency={0,number,#}ms";
+
+    private MessageFormat fmt;
+
+    private Level latencyMeasurementLogLevel = FINE;
+
+    public OPALatencyMeasuringHTTPClient(Logger logger) {
+        super();
+        this.logger = logger;
+    }
+
+    /**
+     * This constructor allows providing additional headers that should be
+     * passed to OPAHTTPClient.
+     *
+     * @param logger
+     * @param headers
+     * @param headers
+     */
+    public OPALatencyMeasuringHTTPClient(Logger logger, Map<String, String> headers) {
+        super(headers);
+        this.logger = logger;
+        this.fmt = new MessageFormat(this.latencyMeasurementFormatString);
+    }
+
+    /**
+     * Modify the format in which the latency measurements are logged.
+     *
+     * The format string should be compatible with java.text.MessageFormat.
+     * The {0} argument will contain the measured request latency in ms, and
+     * the {1} argument will contain the URL path for the HTTP request. The
+     * default format is  "path=''{1}'' latency={0,number,#}ms"
+     *
+     * @param newFormat
+     */
+    public void setLatencyMeasurementFormat(String newFormat) {
+        this.latencyMeasurementFormatString = newFormat;
+        this.fmt = new MessageFormat(this.latencyMeasurementFormatString);
+    }
+
+    /**
+     * Modify the log level at which latency measurements are recorded.
+     *
+     * @param newLevel
+     */
+    public void setLatencyMeasurementLogLevel(Level newLevel) {
+        this.latencyMeasurementLogLevel = newLevel;
+    }
+
+    @Override
+    public HttpResponse<InputStream> send(HttpRequest request)
+            throws IOException, InterruptedException, URISyntaxException {
+
+        String path = request.uri().getPath();
+
+        long startTime = System.nanoTime();
+        HttpResponse<InputStream> response = super.send(request);
+        long endTime = System.nanoTime();
+
+        long sendLatency = endTime - startTime;
+
+        Object[] logArgs = {sendLatency, path};
+
+        logger.log(latencyMeasurementLogLevel, fmt.format(logArgs));
+
+        return response;
+    }
+}
+

--- a/src/main/java/com/styra/opa/utils/OPALatencyMeasuringHTTPClient.java
+++ b/src/main/java/com/styra/opa/utils/OPALatencyMeasuringHTTPClient.java
@@ -13,13 +13,13 @@ import java.util.logging.Logger;
 import static java.util.logging.Level.FINE;
 
 /**
- * This HTTPClient implementation wraps OPAHTTPClient. In addition to
- * (optionally) injecting extra headers into the requests, it can also send log
- * messages to a java.util.logging.Logger instances with latency measurements.
+ * This HTTPClient implementation wraps OPAHTTPClient and has the same
+ * functionality, but also creates log messages indicating the latency for each
+ * request processed.
  */
 public class OPALatencyMeasuringHTTPClient extends OPAHTTPClient {
 
-    private Logger logger;
+    private static Logger logger = Logger.getLogger(OPALatencyMeasuringHTTPClient.class.getName());
 
     private String latencyMeasurementFormatString = "path=''{1}'' latency={0,number,#}ms";
 
@@ -27,9 +27,8 @@ public class OPALatencyMeasuringHTTPClient extends OPAHTTPClient {
 
     private Level latencyMeasurementLogLevel = FINE;
 
-    public OPALatencyMeasuringHTTPClient(Logger logger) {
+    public OPALatencyMeasuringHTTPClient() {
         super();
-        this.logger = logger;
     }
 
     /**
@@ -40,19 +39,18 @@ public class OPALatencyMeasuringHTTPClient extends OPAHTTPClient {
      * @param headers
      * @param headers
      */
-    public OPALatencyMeasuringHTTPClient(Logger logger, Map<String, String> headers) {
+    public OPALatencyMeasuringHTTPClient(Map<String, String> headers) {
         super(headers);
-        this.logger = logger;
         this.fmt = new MessageFormat(this.latencyMeasurementFormatString);
     }
 
     /**
-     * Modify the format in which the latency measurements are logged.
+     * Modify the format in which the latency measurements are logged, the
+     * default is "path=''{1}'' latency={0,number,#}ms".
      *
      * The format string should be compatible with java.text.MessageFormat.
      * The {0} argument will contain the measured request latency in ms, and
-     * the {1} argument will contain the URL path for the HTTP request. The
-     * default format is  "path=''{1}'' latency={0,number,#}ms"
+     * the {1} argument will contain the URL path for the HTTP request.
      *
      * @param newFormat
      */
@@ -62,7 +60,8 @@ public class OPALatencyMeasuringHTTPClient extends OPAHTTPClient {
     }
 
     /**
-     * Modify the log level at which latency measurements are recorded.
+     * Modify the log level at which latency measurements are recorded, the
+     * default is FINE.
      *
      * @param newLevel
      */

--- a/src/test/java/com/styra/opa/OPATest.java
+++ b/src/test/java/com/styra/opa/OPATest.java
@@ -1,6 +1,9 @@
 package com.styra.opa;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.styra.opa.openapi.utils.HTTPClient;
+import com.styra.opa.utils.OPAHTTPClient;
+import com.styra.opa.utils.OPALatencyMeasuringHTTPClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,11 +17,18 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import static java.util.Map.entry;
+import static java.util.logging.Level.ALL;
+import static java.util.logging.Level.INFO;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Testcontainers
 
@@ -218,6 +228,106 @@ class OPATest {
         }
 
         assertEquals(expect, result);
+    }
+
+    @Test
+    public void testOPAEchoWithCustomClient() {
+        // Normally, OPAClient handles instantiating the OPAHTTPClient under
+        // the hood to accommodate custom headers. This test ensures that
+        // passing it to the constructor directly works, since if the client
+        // isn't adding the headers properly then OPA's auth will bounce
+        // the requests.
+
+        HTTPClient httpc = new OPAHTTPClient(headers);
+        OPAClient opa = new OPAClient(address, httpc);
+        Map result = Map.ofEntries(entry("unit", "test"));
+        Map expect = Map.ofEntries(entry("hello", "world"), entry("foo", Map.ofEntries(entry("bar", testIntegerA))));
+
+        try {
+            result = opa.evaluate("policy/echo", Map.ofEntries(
+                entry("hello", "world"),
+                entry("foo", Map.ofEntries(entry("bar", testIntegerA)))
+            ));
+        } catch (OPAException e) {
+            System.out.println("exception: " + e);
+            assertNull(e);
+        }
+
+        assertEquals(expect, result);
+    }
+
+    @Test
+    public void testLatencyMeasurement() {
+        Logger logger = Logger.getLogger("testLatencyMeasurementLogger");
+        RecordingHandler handlerObj = new RecordingHandler();
+        handlerObj.setLevel(ALL);
+        logger.addHandler(handlerObj);
+        logger.setLevel(ALL);
+        logger.setUseParentHandlers(false);
+
+        OPALatencyMeasuringHTTPClient httpc = new OPALatencyMeasuringHTTPClient(logger, headers);
+        httpc.setLatencyMeasurementFormat("LATENCY MEASUREMENT #{0,number,#}#{1}#");
+        httpc.setLatencyMeasurementLogLevel(INFO);
+        OPAClient opa = new OPAClient(address, httpc);
+        Map result = Map.ofEntries(entry("unit", "test"));
+        Map expect = Map.ofEntries(entry("hello", "world"), entry("foo", Map.ofEntries(entry("bar", testIntegerA))));
+
+        try {
+            result = opa.evaluate("policy/echo", Map.ofEntries(
+                entry("hello", "world"),
+                entry("foo", Map.ofEntries(entry("bar", testIntegerA)))
+            ));
+        } catch (OPAException e) {
+            System.out.println("exception: " + e);
+            assertNull(e);
+        }
+
+        assertEquals(expect, result);
+
+        List<LogRecord> recs = handlerObj.getSeenRecs();
+        List<String> logs = new ArrayList<String>();
+        recs.forEach(elem -> logs.add(elem.getLevel().getName() + " " + elem.getMessage()));
+
+        for (String msg : logs) {
+            System.out.printf("DEBUG: log line: %s\n", msg);
+            assertTrue(msg.matches("^INFO LATENCY MEASUREMENT #[0-9]+#/v1/data/policy/echo#$"));
+        }
+    }
+
+    @Test
+    public void testLatencyMeasurementDefaults() {
+        Logger logger = Logger.getLogger("testLatencyMeasurementLogger");
+        RecordingHandler handlerObj = new RecordingHandler();
+        handlerObj.setLevel(ALL);
+        logger.addHandler(handlerObj);
+        logger.setLevel(ALL);
+        logger.setUseParentHandlers(false);
+
+        OPALatencyMeasuringHTTPClient httpc = new OPALatencyMeasuringHTTPClient(logger, headers);
+        OPAClient opa = new OPAClient(address, httpc);
+        Map result = Map.ofEntries(entry("unit", "test"));
+        Map expect = Map.ofEntries(entry("hello", "world"), entry("foo", Map.ofEntries(entry("bar", testIntegerA))));
+
+        try {
+            result = opa.evaluate("policy/echo", Map.ofEntries(
+                entry("hello", "world"),
+                entry("foo", Map.ofEntries(entry("bar", testIntegerA)))
+            ));
+        } catch (OPAException e) {
+            System.out.println("exception: " + e);
+            assertNull(e);
+        }
+
+        assertEquals(expect, result);
+
+        List<LogRecord> recs = handlerObj.getSeenRecs();
+        List<String> logs = new ArrayList<String>();
+        recs.forEach(elem -> logs.add(elem.getLevel().getName() + " " + elem.getMessage()));
+
+        for (String msg : logs) {
+            System.out.printf("DEBUG: log line: %s\n", msg);
+            assertTrue(msg.matches("^FINE path='/v1/data/policy/echo' latency=[0-9]+ms$"));
+        }
     }
 
     @Test

--- a/src/test/java/com/styra/opa/RecordingHandler.java
+++ b/src/test/java/com/styra/opa/RecordingHandler.java
@@ -1,0 +1,27 @@
+package com.styra.opa;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+class RecordingHandler extends Handler {
+    private List<LogRecord> seenRecs = new ArrayList<>();
+
+    @Override
+    public void publish(LogRecord rec) {
+        seenRecs.add(rec);
+    }
+
+    public List<LogRecord> getSeenRecs() {
+        return this.seenRecs;
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void flush() {
+    }
+}


### PR DESCRIPTION
This PR adds a new `OPALatencyMeasuringHTTPClient` class, which can accept a [`java.util.logging.Logger`](https://docs.oracle.com/javase/7/docs/api/java/util/logging/Logger.html) instance to send messages to which record the path element of each HTTP request along with the latency for the request in ms. The format and log level of the messages can be customized.

To make using this client easier, a new constructor for `OPAClient()` is provided which allows any `HTTPClient` implementation to be directly passed in. While this functionality was already possible, it required interacting with the low-level API previously. 