### PR TITLE
Fix chore PR generation

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -22,9 +22,10 @@ java:
     - implementation:com.fasterxml.jackson.core:jackson-annotations:2.17.0
     - api:com.fasterxml.jackson.core:jackson-core:2.17.0
     - implementation:org.apache.httpcomponents:httpcore:4.4.16
+  # NOTE: nebula.lint is added by scripts/fix-build-gradle.sh, see NOTE there
+  # for details on how and why.
   additionalPlugins:
     - id("java")
-    - id "nebula.lint" version "17.8.0"
     - id("checkstyle")
   artifactID: openapi
   clientServerStatusCodesAsErrors: true

--- a/build-extras.gradle
+++ b/build-extras.gradle
@@ -12,8 +12,13 @@ javadocJar {
 }
 
 tasks.withType(Javadoc) {
-  autoLintGradle.enabled = false
-  failOnError false
+    // NOTE: depending on weather or not fix-build-gradle has been run yet, we
+    // may not have the nebula.lint plugin installed. If it isn't present, we
+    // need the build to still pass to keep the automation happy.
+    if (project.hasProperty('autoLintGradle')) {
+        autoLintGradle.enabled = false
+    }
+    failOnError false
 }
 
 // https://discuss.gradle.org/t/how-to-exclude-checkstyle-task-from-build-task/6692/5
@@ -32,19 +37,21 @@ tasks.withType(Checkstyle) {
 }
 
 task lint {
-    autoLintGradle.enabled = true
     dependsOn checkstyleTest
     dependsOn checkstyleMain
-    gradleLint {
-        criticalRules=['all-dependency']
-        reportFormat = 'text'
-        excludedRules = [
-            // Enabling recommended-versions causes Gradle to complain about
-            // testcontainers, but applying the suggested fix (removing the version
-            // numbers from all but one of the testImplementation lines) causes
-            // gradle to fail in a more obscure way that I don't understand.
-            "recommended-versions"
-        ]
+    if (project.hasProperty('autoLintGradle')) {
+        autoLintGradle.enabled = true
+        gradleLint {
+            criticalRules=['all-dependency']
+            reportFormat = 'text'
+            excludedRules = [
+                // Enabling recommended-versions causes Gradle to complain about
+                // testcontainers, but applying the suggested fix (removing the version
+                // numbers from all but one of the testImplementation lines) causes
+                // gradle to fail in a more obscure way that I don't understand.
+                "recommended-versions"
+            ]
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ plugins {
     id 'maven-publish'
     id 'signing'
     id("java")
-    id "nebula.lint" version "17.8.0"
     id("checkstyle")
+    id "nebula.lint" version "17.8.0"
 }
 
 compileJava.options.encoding = "UTF-8"


### PR DESCRIPTION
I discovered that the chore PRs were breaking, consider [this build log as an example](https://github.com/StyraInc/opa-java/actions/runs/10189648615/job/28188071195). The breakage is because SE's generation logic is failing to compile the SDK after it is generated, which in turn is due to failing lint checks on the Gradle dependencies:

```
  > Task :autoLintGradle FAILED
  
  This project contains lint violations. A complete listing of the violations follows. 
  Because some were serious, the overall build status has been changed to FAILED
  
  error     unused-dependency                  this dependency is unused and can be removed
  build.gradle:125
  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
  
  error     unused-dependency                  this dependency is a service provider unused at compileClasspath time and can be moved to the runtimeOnly configuration (no auto-fix available)
  build.gradle:128
  testImplementation 'org.testcontainers:testcontainers:1.19.7'
  
  error     unused-dependency                  this dependency is unused and can be removed
  build.gradle:128
  testImplementation 'org.testcontainers:testcontainers:1.19.7'
  
  error     unused-dependency                  this dependency is unused and can be removed
```

The thing is, these warnings are spurious and go away after the post build hook runs... which it never gets to because the build fails too soon. This problem was previously masked by the fact that I was inserting the nebula.lint plugin after SE's automation ran anyway back before `additionalPlugins` was added to `gen.yaml`. Once I adopted `additionalPlugins`, the builds started failing because nebula.lint was present at the time the SE tools tried to compile the SDK.

This PR rectifies the issue by going back to the old way of inserting the nebula.lint plugin, though it keeps `additionalPlugins` for all other types of plugins. 